### PR TITLE
feat(frontend): add heading styles

### DIFF
--- a/packages/semantic/src/elements/_headings.scss
+++ b/packages/semantic/src/elements/_headings.scss
@@ -1,0 +1,23 @@
+h1 {
+  font-size: px-to-rem(24px);
+}
+
+h2 {
+  font-size: px-to-rem(22px);
+}
+
+h3 {
+  font-size: px-to-rem(18px);
+}
+
+h4 {
+  font-size: px-to-rem(16px);
+}
+
+h5 {
+  font-size: px-to-rem(12px);
+}
+
+h6 {
+  font-size: px-to-rem(10px);
+}


### PR DESCRIPTION
According to this file structure...

```
|-- semantic/
|   |-- src/
|       |-- elements/
|           |-- _headings.scss
|           |-- ...
|-- utilities-class/
|   |-- src/
|       |-- components/
|           |-- _typography.scss
|           |-- ...
```

I think that styles related to headings in the `_typography.scss`' partial should be removed in order to avoid style duplication (#75).